### PR TITLE
feat(header/footer): add short header/footer annotator

### DIFF
--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -30,7 +30,7 @@ use crate::lang::Lang;
 use crate::pipelines::oscardoc::types::{LocationBuilder, ShardResult};
 use crate::pipelines::pipeline::Pipeline;
 use crate::sources::commoncrawl::Wet;
-use crate::transformers::{self, Annotate, Transform};
+use crate::transformers::{self, Annotate, Annotator, Transform};
 use log::{debug, error, info, warn};
 use rayon::prelude::*;
 use warc::BufferedBody;
@@ -174,11 +174,9 @@ impl OscarDoc {
         });
 
         // annotate
-        let adult_filter = transformers::ContentDetector::with_defaults()?;
-        let short_sentence_annotator = transformers::ShortSentences::default();
+        let annotator = Annotator::default();
         let record_iter = record_iter.map(|(loc, mut r)| {
-            adult_filter.annotate(&mut r);
-            short_sentence_annotator.annotate(&mut r);
+            annotator.annotate(&mut r);
             (r, loc.build().unwrap())
         });
 

--- a/src/transformers/annotate.rs
+++ b/src/transformers/annotate.rs
@@ -1,7 +1,32 @@
 //! Annotate trait
+use super::header::Header;
+use super::ContentDetector;
+use super::ShortSentences;
 use crate::pipelines::oscardoc::types::Document;
 
 /// Annotations provide contextual information about content.
 pub trait Annotate {
     fn annotate(&self, doc: &mut Document);
+}
+
+/// Annotator enables annotation chaining, adding multiple annotators and
+/// doing the annotation process in one step.
+pub struct Annotator(Vec<Box<dyn Annotate + Sync>>);
+
+impl Annotate for Annotator {
+    fn annotate(&self, doc: &mut Document) {
+        for annotator in &self.0 {
+            annotator.annotate(doc);
+        }
+    }
+}
+
+impl Default for Annotator {
+    fn default() -> Self {
+        Self(vec![
+            Box::new(ShortSentences::default()),
+            Box::new(ContentDetector::with_defaults().unwrap()),
+            Box::new(Header::default()),
+        ])
+    }
 }

--- a/src/transformers/header.rs
+++ b/src/transformers/header.rs
@@ -1,0 +1,204 @@
+use crate::pipelines::oscardoc::types::Document;
+
+use super::Annotate;
+
+/// Header/Footer annotator.
+///
+/// Checks for short sentences in the beginnning/end of documents, and flags if there's too much.
+struct Header {
+    header_pctg: f64,
+    threshold_pctg: f64,
+    min_length: usize,
+}
+
+impl Default for Header {
+    /// Default values are 20% of the document for the header/footer, flagging if >50% of the sentences are short, and < 100 lines = short sentence.
+    fn default() -> Self {
+        Self {
+            header_pctg: 0.2,
+            threshold_pctg: 0.5,
+            min_length: 100,
+        }
+    }
+}
+
+impl Annotate for Header {
+    fn annotate(&self, doc: &mut Document) {
+        let nb_lines = doc.content().lines().count();
+
+        // there could be better ways of casting this.
+        let nb_lines_header = (nb_lines as f64 * self.header_pctg).floor();
+        let treshold_lines = (nb_lines_header as f64 * self.threshold_pctg).floor() as u64;
+        let nb_lines_header = nb_lines_header as usize;
+
+        // iterate over the header, counting short lines
+        let short_lines_count = self.count_short_lines(doc.content().lines().take(nb_lines_header));
+
+        // moving the if in the for loop may increase/decrease performance?
+        if short_lines_count >= treshold_lines {
+            doc.metadata_mut().set_annotation("header".to_string());
+        }
+
+        let short_lines_count =
+            self.count_short_lines(doc.content().lines().rev().take(nb_lines_header));
+
+        if short_lines_count >= treshold_lines {
+            doc.metadata_mut().set_annotation("footer".to_string());
+        }
+    }
+}
+
+impl Header {
+    fn new(header_pctg: f64, threshold_pctg: f64, min_length: usize) -> Self {
+        Self {
+            header_pctg,
+            threshold_pctg,
+            min_length,
+        }
+    }
+
+    #[inline]
+    fn count_short_lines<'a>(&self, lines: impl Iterator<Item = &'a str>) -> u64 {
+        // reset counter
+        let mut short_lines_count = 0;
+
+        for line in lines {
+            if line.len() < self.min_length {
+                short_lines_count += 1;
+            }
+        }
+
+        short_lines_count
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use crate::{
+        pipelines::oscardoc::types::{Document, Metadata},
+        transformers::Annotate,
+    };
+
+    use super::Header;
+
+    #[test]
+    fn lengthy_enough() {
+        let annotator = Header::new(0.30, 0.60, 30);
+        let text = r"This is a lengthy enough sentence! Or at least I hope :)
+        This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)";
+
+        let mut doc = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        annotator.annotate(&mut doc);
+        assert_eq!(doc.metadata().annotation(), None);
+    }
+
+    #[test]
+    fn test_header() {
+        let annotator = Header::new(0.30, 0.60, 30);
+        let text = r"This is a lengthy enough sentence! Or at least I hope :)
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+oop, tiny one here
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)";
+
+        let mut doc = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        annotator.annotate(&mut doc);
+        assert_eq!(
+            doc.metadata().annotation(),
+            Some(&vec!["header".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_footer() {
+        let annotator = Header::new(0.30, 0.60, 30);
+        let text = r"This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
+short one but it's ok
+short one but it's ok
+This is a lengthy enough sentence! Or at least I hope :)";
+
+        let mut doc = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        annotator.annotate(&mut doc);
+        assert_eq!(
+            doc.metadata().annotation(),
+            Some(&vec!["footer".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_both() {
+        let annotator = Header::new(0.30, 0.60, 30);
+        let text = r"This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
+short one but it's ok
+short one but it's ok
+short one but it's ok
+short one but it's ok
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
+short one but it's ok
+short one but it's ok
+This is a lengthy enough sentence! Or at least I hope :)";
+
+        let mut doc = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        annotator.annotate(&mut doc);
+        assert_eq!(
+            doc.metadata().annotation(),
+            Some(&vec!["header".to_string(), "footer".to_string()])
+        );
+    }
+}

--- a/src/transformers/header.rs
+++ b/src/transformers/header.rs
@@ -9,7 +9,7 @@ use super::Annotate;
 /// Header/Footer annotator.
 ///
 /// Checks for short sentences in the beginnning/end of documents, and flags if there's too much.
-struct Header {
+pub struct Header {
     header_pctg: f64,
     threshold_pctg: f64,
     min_length: usize,

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -13,10 +13,11 @@ mod header;
 mod sentence_filter;
 mod transform;
 
+pub use annotate::Annotate;
+pub use annotate::Annotator;
 pub use content_detector::ContentDetector;
+pub use header::Header;
 pub use sentence_filter::Conv;
 pub use sentence_filter::RemoveShortSentences;
 pub use sentence_filter::ShortSentences;
-
-pub use annotate::Annotate;
 pub use transform::Transform;

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -9,6 +9,7 @@ Transformers can either (or both) [Annotate] content or [Transform] it:
 
 mod annotate;
 mod content_detector;
+mod header;
 mod sentence_filter;
 mod transform;
 


### PR DESCRIPTION
Adds an annotator that watches the number of short sentences in header/footer and adds an annotation if there's too many. 

The PR lacks documentation to be ready to merge.