### PR TITLE
Noisy annotation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ avro-rs = { version = "0.13.0", features = ["snappy"] }
 unicode-script = "0.5.4"
 unicode-segmentation = "1.8.0"
 csv = "1.1.6"
+unic-ucd = "0.9.0"
 
 [dev-dependencies]
 rand_distr = "0.4.2"
@@ -53,4 +54,8 @@ harness = false
 
 [[bench]]
 name = "pipeline_bench_rayon"
+harness = false
+
+[[bench]]
+name = "annotate_noisy"
 harness = false

--- a/benches/annotate_noisy.rs
+++ b/benches/annotate_noisy.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ungoliant::{
+    identifiers::FastText,
+    pipelines::oscardoc::types::{Document, Metadata},
+    transformers::{Annotate, Noisy},
+};
+pub fn noisy(c: &mut Criterion) {
+    let mut documents: Vec<Document> = [
+        "//////////////////////////////////////////////.",
+        "lorem ipsum dolor sit ////////////////////////.",
+        "lore////mmm////m ipsum d///////olor//////sit a.",
+        "lorem ipsum dolor sit amet.",
+    ]
+    .into_iter()
+    .map(String::from)
+    .map(|content| Document::new(content, HashMap::new(), Metadata::default()))
+    .collect();
+    let a = Noisy::default();
+    c.bench_function("noisy_annotate", |b| {
+        b.iter(|| {
+            let documents = documents.clone();
+            for mut d in documents {
+                a.annotate(black_box(&mut d))
+            }
+        })
+    });
+}
+
+criterion_group!(benches, noisy);
+criterion_main!(benches);

--- a/src/transformers/annotate.rs
+++ b/src/transformers/annotate.rs
@@ -1,5 +1,6 @@
 //! Annotate trait
 use super::header::Header;
+use super::noisy::Noisy;
 use super::ContentDetector;
 use super::ShortSentences;
 use crate::pipelines::oscardoc::types::Document;
@@ -27,6 +28,7 @@ impl Default for Annotator {
             Box::new(ShortSentences::default()),
             Box::new(ContentDetector::with_defaults().unwrap()),
             Box::new(Header::default()),
+            Box::new(Noisy::default()),
         ])
     }
 }

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -13,10 +13,12 @@ mod header;
 mod sentence_filter;
 mod transform;
 
+mod noisy;
 pub use annotate::Annotate;
 pub use annotate::Annotator;
 pub use content_detector::ContentDetector;
 pub use header::Header;
+pub use noisy::Noisy;
 pub use sentence_filter::Conv;
 pub use sentence_filter::RemoveShortSentences;
 pub use sentence_filter::ShortSentences;

--- a/src/transformers/noisy.rs
+++ b/src/transformers/noisy.rs
@@ -41,10 +41,11 @@ impl Annotate for Noisy {
         let nb_chars = doc.content().chars().count();
         let threshold = (nb_chars as f64 * self.threshold).floor() as usize;
 
-        let letters = doc
-            .content()
-            .chars()
-            .map(|c| GeneralCategory::of(c).is_letter());
+        let letters = doc.content().chars().map(|c| {
+            let gc = GeneralCategory::of(c);
+
+            gc.is_letter() || gc.is_mark()
+        });
 
         let mut nonletter_count = 0;
         let mut letter_count = 0;
@@ -73,6 +74,8 @@ impl Annotate for Noisy {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
+    use unic_ucd::GeneralCategory;
 
     use crate::{
         pipelines::{oscardoc::types::Document, oscardoc::types::Metadata},
@@ -117,6 +120,27 @@ mod tests {
         Duis dui ipsum, lacinia at ornare vitae, fringilla eu lorem. 
         Aenean nec justo neque. "
             .to_string();
+        let mut d = Document::new(content, HashMap::new(), Metadata::default());
+        let a = Noisy::default();
+        a.annotate(&mut d);
+
+        assert!(d.metadata().annotation().is_none())
+    }
+
+    #[test]
+    fn script() {
+        let content = "ക്ഷീണിച്ചു തളര്‍ന്നു ചുറ്റിലുമുള്ള ലോകത്തിന്റെ ഔപചാരിതകളെയെല്ലാം 
+        കവച്ചു വെച്ച് കിടന്നുറങ്ങുന്ന ജമാലിനെ മിക്കപ്പോഴും ഈ ഉച്ചയുറക്കത്തില്‍ നിന്നും 
+        വിളിച്ചുണര്‍ത്തിയിരുന്നത് ചെരിഞ്ഞു പറക്കുന്ന ഒരു വിമാനചിത്രം പതിച്ച ഇളംനീല 
+        എയര്‍മെയിലായിരുന്നു. ഗ്രീഷ്മകാല നട്ടുച്ചയുടെ ചുട്ടുപൊള്ളുന്ന വെയില്‍ മുഴുവന്‍ 
+        ഏറ്റുവാങ്ങിത്തളര്‍ന്ന ശരീരം പതിവുപോലെ പിന്നെയും പിന്നെയും 
+        അബോധത്തിലേക്ക്‌ നൂണ്ടു പോവാന്‍ നിര്‍ബ്ബ‍ന്ധിച്ചിട്ടും അതനുസരിക്കാതെ 
+        വന്നുമൂടുന്ന നിദ്രയെ തല കുടഞ്ഞെറിഞ്ഞ് അന്നും അയാള്‍ പെട്ടെന്ന് തന്നെ 
+        കട്ടിലില്‍ എഴുനേറ്റിരുന്നു. തലേന്ന് രാത്രി നേരമേറെ വൈകി തന്റെ തൂവിപ്പോയ 
+        ദൈന്യങ്ങള്‍ അരിച്ചെടുത്തും സ്നേഹമിടിപ്പുകളു
+        "
+        .to_string();
+
         let mut d = Document::new(content, HashMap::new(), Metadata::default());
         let a = Noisy::default();
         a.annotate(&mut d);

--- a/src/transformers/noisy.rs
+++ b/src/transformers/noisy.rs
@@ -1,0 +1,126 @@
+/*! Annotates noisy content
+
+Noisy content is content that has a too low letters/punctuation ratio.
+ *  !*/
+
+use unic_ucd::GeneralCategory;
+
+use super::Annotate;
+use crate::pipelines::oscardoc::types::Document;
+pub struct Noisy {
+    threshold: f64,
+}
+
+impl Default for Noisy {
+    fn default() -> Self {
+        Self { threshold: 0.5 }
+    }
+}
+impl Annotate for Noisy {
+    // fn annotate(&self, doc: &mut Document) {
+    //     // TODO: use counters?
+    //     let (letters, nonletters): (Vec<bool>, Vec<bool>) = doc
+    //         .content()
+    //         .chars()
+    //         .map(|c| GeneralCategory::of(c).is_letter())
+    //         .partition(|x| *x);
+
+    //     let letters = letters.len();
+    //     let nonletters = nonletters.len();
+    //     let total_chars = (letters + nonletters) as f64;
+    //     let threshold = self.threshold * total_chars;
+
+    //     if nonletters > threshold.floor() as usize {
+    //         doc.metadata_mut().set_annotation("noisy".to_string());
+    //     }
+    // }
+
+    fn annotate(&self, doc: &mut Document) {
+        // TODO: use counters?
+
+        let nb_chars = doc.content().chars().count();
+        let threshold = (nb_chars as f64 * self.threshold).floor() as usize;
+
+        let letters = doc
+            .content()
+            .chars()
+            .map(|c| GeneralCategory::of(c).is_letter());
+
+        let mut nonletter_count = 0;
+        let mut letter_count = 0;
+
+        for i in letters {
+            if !i {
+                nonletter_count += 1;
+
+                // if count is more than what we consider to be the threshold, stop there
+                if nonletter_count > threshold {
+                    doc.metadata_mut().set_annotation("noisy".to_string());
+                    break;
+                }
+            } else {
+                letter_count += 1;
+
+                // same logic applies
+                if letter_count > threshold {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        pipelines::{oscardoc::types::Document, oscardoc::types::Metadata},
+        transformers::Annotate,
+    };
+
+    use super::Noisy;
+
+    #[test]
+    fn test_full_noise() {
+        let content = "/////////////////////////".to_string();
+        let mut d = Document::new(content, HashMap::new(), Metadata::default());
+        let a = Noisy::default();
+        a.annotate(&mut d);
+
+        assert!(d
+            .metadata()
+            .annotation()
+            .unwrap()
+            .contains(&"noisy".to_string()));
+    }
+
+    #[test]
+    fn almost_full_noise() {
+        let content = "/a//a////a////a/a//a////a///a/a//a/".to_string();
+        let mut d = Document::new(content, HashMap::new(), Metadata::default());
+        let a = Noisy::default();
+        a.annotate(&mut d);
+
+        assert!(d
+            .metadata()
+            .annotation()
+            .unwrap()
+            .contains(&"noisy".to_string()));
+    }
+
+    #[test]
+    fn standard_punctuation() {
+        let content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+        Nam tempor magna ac justo sollicitudin, eu posuere purus sollicitudin. 
+        Aliquam erat volutpat. 
+        Duis dui ipsum, lacinia at ornare vitae, fringilla eu lorem. 
+        Aenean nec justo neque. "
+            .to_string();
+        let mut d = Document::new(content, HashMap::new(), Metadata::default());
+        let a = Noisy::default();
+        a.annotate(&mut d);
+
+        assert!(d.metadata().annotation().is_none())
+    }
+}


### PR DESCRIPTION
Adds `noisy` as a label on documents having a letter/punctuation ratio that is not good enough.

The performance currently takes an important hit.

On my machine (8core), using 25 shards, generation takes ~140s without annotations, ~170 with annotations, with the major part of the increase spent on the noisy annotator.