### PR TITLE
Pipeline operations order

### DIFF
--- a/src/identifiers/fasttext.rs
+++ b/src/identifiers/fasttext.rs
@@ -1,7 +1,7 @@
 //! Fasttext identifier
-use std::path::Path;
+use std::{collections::HashMap, path::Path, str::Lines};
 
-use crate::error::Error;
+use crate::{error::Error, pipelines::oscardoc::types::Document};
 use fasttext::{FastText as FastTextLib, Prediction};
 
 use super::{identifier, Identification};
@@ -94,7 +94,7 @@ impl FastText {
     }
 }
 
-impl identifier::Identifier for FastText {
+impl identifier::Identifier<&str> for FastText {
     fn identify(&self, sentence: &str) -> Result<Option<Identification>, Error> {
         let prediction = self
             .predictor
@@ -111,6 +111,13 @@ impl identifier::Identifier for FastText {
         }
     }
 }
+
+impl identifier::Identifier<&Document> for FastText {
+    fn identify(&self, document: &Document) -> Result<Option<Identification>, Error> {
+        todo!();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/identifiers/fasttext.rs
+++ b/src/identifiers/fasttext.rs
@@ -1,5 +1,5 @@
 //! Fasttext identifier
-use std::{collections::HashMap, path::Path, str::Lines};
+use std::path::Path;
 
 use crate::{error::Error, pipelines::oscardoc::types::Document};
 use fasttext::{FastText as FastTextLib, Prediction};
@@ -109,12 +109,6 @@ impl identifier::Identifier<&str> for FastText {
         } else {
             Ok(None)
         }
-    }
-}
-
-impl identifier::Identifier<&Document> for FastText {
-    fn identify(&self, document: &Document) -> Result<Option<Identification>, Error> {
-        todo!();
     }
 }
 

--- a/src/identifiers/identifier.rs
+++ b/src/identifiers/identifier.rs
@@ -62,9 +62,9 @@ impl From<Prediction> for Identification {
         }
     }
 }
-pub trait Identifier {
+pub trait Identifier<T> {
     /// returns a language identification token (from [crate::lang::LANG]).
-    fn identify(&self, sentence: &str) -> Result<Option<Identification>, Error>;
+    fn identify(&self, sentence: T) -> Result<Option<Identification>, Error>;
 }
 
 #[cfg(test)]

--- a/src/identifiers/multilingual.rs
+++ b/src/identifiers/multilingual.rs
@@ -51,11 +51,7 @@ impl Filter<&[(Option<Identification>, usize)]> for StrictMultilingual {
             .iter()
             .filter(|(id, _)| {
                 if let Some(id) = id {
-                    if id.prob() >= &self.threshold_confidence {
-                        true
-                    } else {
-                        false
-                    }
+                    id.prob() >= &self.threshold_confidence
                 } else {
                     false
                 }

--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -37,6 +37,7 @@ use warc::BufferedBody;
 use warc::{Record, WarcHeader};
 
 use crate::io::LangFilesDoc;
+
 pub struct OscarDoc {
     src: PathBuf,
     dst: PathBuf,
@@ -177,6 +178,15 @@ impl OscarDoc {
             (r, loc.build().unwrap())
         });
 
+        let record_iter = record_iter.filter_map(|(r, loc): (Document, Location)| {
+            if r.metadata().annotation() == Some(&vec!["noisy".to_string(), "tiny".to_string()]) {
+                debug!("removed document {:?} for noisy+tiny", r.warc_id());
+                None
+            } else {
+                Some((r, loc))
+            }
+        });
+
         let records: Vec<(_, _)> = record_iter.collect();
         info!("Shard {}: Got {} documents", shard_id, records.len());
 
@@ -215,14 +225,14 @@ impl OscarDoc {
                 if let Ok(ref ide) = id {
                     // map Identification to its lang, or keep None to store the "None" language identification
                     let ide_label = ide.as_ref().map(|i| *i.label());
-
+                    let ide_prob = ide.as_ref().map(|i| *i.prob());
                     // get length of current line
                     let byte_count = line.bytes().count();
 
                     lang_count
                         .entry(ide_label)
                         .and_modify(|count| *count += byte_count)
-                        .or_insert(byte_count);
+                        .or_insert((byte_count));
 
                     total_count += byte_count;
                 }
@@ -249,6 +259,7 @@ impl OscarDoc {
         // build a document and return it if the document language is not the unknown one.
         if let Some((Some(id), lang_byte_count)) = document_language {
             // build an Identification with prob = number of bytes from most identified language / total number of bytes
+            debug!("{:?}: {}/{}", id, lang_byte_count, total_count);
             let document_identification =
                 Identification::new(*id, *lang_byte_count as f32 / total_count as f32);
 

--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -99,9 +99,6 @@ impl OscarDoc {
         let shard = Wet::from_path_gzip(&shard_path)?;
         let record_iter = shard.iter.enumerate().par_bridge();
 
-        // get specified filter or resort to default filter kind
-        let f = filter.unwrap_or_default();
-
         // only get valid records, print errors
         let record_iter = record_iter.filter_map(|(idx, record)| match record {
             Ok(r) => Some((idx, r)),
@@ -147,6 +144,9 @@ impl OscarDoc {
                 }
             }
         });
+
+        // get specified filter or resort to default filter kind
+        let f = filter.unwrap_or_default();
 
         // get iterator on filtered records.
         // only get records that are valid *and* pass the filter.

--- a/src/pipelines/oscardoc/pipeline.rs
+++ b/src/pipelines/oscardoc/pipeline.rs
@@ -246,7 +246,7 @@ impl OscarDoc {
 
         // divide each probability sum to get values between 0 and 1
         for (_, count_times_prob) in lang_count.values_mut() {
-            *count_times_prob = *count_times_prob / total_count as f32;
+            *count_times_prob /= total_count as f32;
         }
 
         // see if the record meets multilingual criteria

--- a/src/transformers/annotate.rs
+++ b/src/transformers/annotate.rs
@@ -3,6 +3,7 @@ use super::header::Header;
 use super::noisy::Noisy;
 use super::ContentDetector;
 use super::ShortSentences;
+use super::TinyDocument;
 use crate::pipelines::oscardoc::types::Document;
 
 /// Annotations provide contextual information about content.
@@ -25,6 +26,7 @@ impl Annotate for Annotator {
 impl Default for Annotator {
     fn default() -> Self {
         Self(vec![
+            Box::new(TinyDocument::default()),
             Box::new(ShortSentences::default()),
             Box::new(ContentDetector::with_defaults().unwrap()),
             Box::new(Header::default()),

--- a/src/transformers/header.rs
+++ b/src/transformers/header.rs
@@ -41,8 +41,7 @@ impl Annotate for Header {
 
         // iterate over the header, counting short lines
         let short_lines_count = self.count_short_lines(doc.content().lines().take(nb_lines_header));
-
-        if short_lines_count >= treshold_lines {
+        if short_lines_count > treshold_lines {
             doc.metadata_mut().set_annotation("header".to_string());
         }
 
@@ -50,7 +49,7 @@ impl Annotate for Header {
         let short_lines_count =
             self.count_short_lines(doc.content().lines().rev().take(nb_lines_header));
 
-        if short_lines_count >= treshold_lines {
+        if short_lines_count > treshold_lines {
             doc.metadata_mut().set_annotation("footer".to_string());
         }
     }
@@ -243,5 +242,36 @@ This is a lengthy enough sentence! Or at least I hope :)";
         let h = Header::new(0.10, 0.50, 30);
         let short_count = h.count_short_lines(text.lines().take(10));
         assert_eq!(short_count, 5);
+    }
+    #[test]
+    fn test_short_nblines_valid_doc() {
+        let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a diam mollis, scelerisque arcu sed, bibendum ligula. Curabitur convallis urna auctor mi varius, 
+at sagittis arcu vehicula. Maecenas ante velit, bibendum vel ligula quis, dapibus eleifend nibh. Vivamus dapibus nibh non eros feugiat accumsan. In ut risus vitae risus aliquet dictum blandit sed velit. Fusce semper sagittis egestas. Cras orci diam, tristique vel dictum a, mollis in velit. 
+Suspendisse nisi tellus, fermentum eu cursus sit amet, dictum ornare nisi. Donec rhoncus nisi lacus, at malesuada nunc egestas nec. Nunc in elit nunc. Quisque id euismod lectus, id porttitor ante. Duis ac nibh tincidunt, vestibulum orci nec, sagittis tortor. 
+Sed non ipsum et lacus mattis eleifend. Donec ultricies efficitur enim, non consectetur lorem efficitur et. Pellentesque non malesuada magna, vitae congue arcu. 
+Aliquam tempus volutpat laoreet. Etiam facilisis nisl turpis, sed euismod justo euismod sit amet. Phasellus eget urna sodales, luctus dolor vel, malesuada arcu. Nullam tincidunt sem et nibh volutpat volutpat.
+Etiam ornare ligula sollicitudin scelerisque finibus. Suspendisse orci odio, laoreet sed sapien ut, dignissim venenatis risus.";
+        let h = Header::default();
+        let mut d = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        h.annotate(&mut d);
+        assert_eq!(d.metadata().annotation(), None);
+    }
+
+    #[test]
+    fn test_one_long_sentence() {
+        let text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed a diam mollis, scelerisque arcu sed, bibendum ligula. Curabitur convallis urna auctor mi varius.";
+        let h = Header::default();
+        let mut d = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        h.annotate(&mut d);
+        assert_eq!(d.metadata().annotation(), None);
+    }
+
+    #[test]
+    fn test_one_short_sentence() {
+        let text = "Lorem ipsum dolor sit amet";
+        let h = Header::default();
+        let mut d = Document::new(text.to_string(), HashMap::new(), Metadata::default());
+        h.annotate(&mut d);
+        assert_eq!(d.metadata().annotation(), None);
     }
 }

--- a/src/transformers/header.rs
+++ b/src/transformers/header.rs
@@ -172,7 +172,7 @@ This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
-This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
 short one but it's ok
 short one but it's ok
 short one but it's ok
@@ -203,7 +203,7 @@ This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
 This is a lengthy enough sentence! Or at least I hope :)
-This is a lengthy enough sentence! Or at least I hope :)
+short one but it's ok
 short one but it's ok
 short one but it's ok
 short one but it's ok

--- a/src/transformers/mod.rs
+++ b/src/transformers/mod.rs
@@ -11,6 +11,7 @@ mod annotate;
 mod content_detector;
 mod header;
 mod sentence_filter;
+mod tiny;
 mod transform;
 
 mod noisy;
@@ -22,4 +23,5 @@ pub use noisy::Noisy;
 pub use sentence_filter::Conv;
 pub use sentence_filter::RemoveShortSentences;
 pub use sentence_filter::ShortSentences;
+pub use tiny::TinyDocument;
 pub use transform::Transform;

--- a/src/transformers/sentence_filter.rs
+++ b/src/transformers/sentence_filter.rs
@@ -213,7 +213,6 @@ impl RemoveShortSentences {
                 (sentences, ranges)
             }
             _ => {
-                error!("Record only had short sentences at transform step! This shouldn't happen!",);
                 // set content to empty string
                 (String::new(), Vec::new())
             }

--- a/src/transformers/sentence_filter.rs
+++ b/src/transformers/sentence_filter.rs
@@ -4,7 +4,6 @@ use std::ops::RangeInclusive;
 
 use itertools::Itertools;
 use log::debug;
-use log::error;
 use warc::BufferedBody;
 use warc::Record;
 

--- a/src/transformers/sentence_filter.rs
+++ b/src/transformers/sentence_filter.rs
@@ -5,6 +5,8 @@ use std::ops::RangeInclusive;
 use itertools::Itertools;
 use log::debug;
 use log::error;
+use warc::BufferedBody;
+use warc::Record;
 
 use crate::{
     filtering::{sentence::Length, Filter},
@@ -186,81 +188,68 @@ impl RemoveShortSentences {
         }
     }
 
-    /// get filter detection threshold
-    fn filter_min_length(&self) -> &usize {
-        self.filter.min_size()
-    }
-
-    // pub fn transform_idx(&self, mut doc: Document) -> (Document, Vec<RangeInclusive<usize>>) {
-    //     let lines = doc.content().lines();
-    //     let s: Vec<(usize, &str)> = lines
-    //         .enumerate()
-    //         .skip_while(|(_, sentence)| !self.filter.detect(sentence))
-    //         .collect();
-
-    //     // do the same thing while reversing the iterator
-    //     // this way, we skip the short sentences at the end
-    //     let s: Vec<(usize, &str)> = s
-    //         .into_iter()
-    //         .rev()
-    //         .skip_while(|(_, sentence)| !self.filter.detect(sentence))
-    //         //.map(|(idx, _)| idx)
-    //         .collect();
-
-    //     // if we did not get start or end, we return an empty vector
-    //     // meaning that we keed nothing. (analogous to transform_own)
-    //     match (s.first(), s.last()) {
-    //         (Some(end), Some(start)) => {
-    //             let ranges = vec![start.0..=end.0];
-    //             let sentences = s.into_iter().rev().map(|(_, sentence)| sentence).join("\n");
-
-    //             doc.set_content(sentences);
-
-    //             (doc, ranges)
-    //         }
-    //         _ => (doc, Vec::new()),
-    //     }
-    // }
-}
-
-impl Transform for RemoveShortSentences {
-    fn transform(&self, doc: &mut Document) -> Vec<RangeInclusive<usize>> {
-        let lines = doc.content().lines();
+    /// extracts indices of the document content, ignoring short lines at start/end.
+    fn extract_indices<'a>(&self, lines: std::str::Lines<'a>) -> Vec<(usize, &'a str)> {
         let s: Vec<(usize, &str)> = lines
             .enumerate()
             .skip_while(|(_, sentence)| !self.filter.detect(sentence))
             .collect();
-
-        // do the same thing while reversing the iterator
-        // this way, we skip the short sentences at the end
         let s: Vec<(usize, &str)> = s
             .into_iter()
             .rev()
             .skip_while(|(_, sentence)| !self.filter.detect(sentence))
-            //.map(|(idx, _)| idx)
             .collect();
+        s
+    }
 
-        // if we did not get start or end, we return an empty vector
-        // meaning that we keed nothing. (analogous to transform_own)
+    /// build content from extracted indices, returning a unique String along with the indices
+    /// that can be used to rebuild the content.
+    fn build_content(s: Vec<(usize, &str)>) -> (String, Vec<RangeInclusive<usize>>) {
         match (s.first(), s.last()) {
             (Some(end), Some(start)) => {
                 let ranges = vec![start.0..=end.0];
                 let sentences = s.into_iter().rev().map(|(_, sentence)| sentence).join("\n");
 
-                doc.set_content(sentences);
-
-                ranges
+                (sentences, ranges)
             }
             _ => {
-                error!(
-                    "Record {} only had short sentences at transform step! This shouldn't happen!",
-                    doc.warc_id()
-                );
+                error!("Record only had short sentences at transform step! This shouldn't happen!",);
                 // set content to empty string
-                doc.set_content(String::new());
-                Vec::new()
+                (String::new(), Vec::new())
             }
         }
+    }
+    /// get filter detection threshold
+    fn filter_min_length(&self) -> &usize {
+        self.filter.min_size()
+    }
+}
+
+impl Transform<Document> for RemoveShortSentences {
+    fn transform(&self, doc: &mut Document) -> Vec<RangeInclusive<usize>> {
+        let lines = doc.content().lines();
+
+        // TODO: fuse those two methods?
+        let s = self.extract_indices(lines);
+        let (content, ranges) = Self::build_content(s);
+
+        doc.set_content(content);
+
+        ranges
+    }
+}
+
+impl Transform<Record<BufferedBody>> for RemoveShortSentences {
+    fn transform(&self, doc: &mut Record<BufferedBody>) -> Vec<RangeInclusive<usize>> {
+        let stringified = String::from_utf8_lossy(doc.body());
+        let lines = stringified.lines();
+        let s = self.extract_indices(lines);
+
+        // if we did not get start or end, we return an empty vector
+        // meaning that we keed nothing. (analogous to transform_own)
+        let (content, ranges) = Self::build_content(s);
+        doc.replace_body(content);
+        ranges
     }
 }
 

--- a/src/transformers/tiny.rs
+++ b/src/transformers/tiny.rs
@@ -18,3 +18,42 @@ impl Default for TinyDocument {
         Self { threshold: 5 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        pipelines::oscardoc::types::{Document, Metadata},
+        transformers::Annotate,
+    };
+
+    use super::TinyDocument;
+
+    #[test]
+    fn test_annotation() {
+        let b = "this is a short
+        short document";
+        let mut d = Document::new(b.to_string(), HashMap::new(), Metadata::default());
+
+        let annotator = TinyDocument::default();
+        annotator.annotate(&mut d);
+
+        assert_eq!(d.metadata().annotation(), Some(&vec!["tiny".to_string()]));
+    }
+
+    #[test]
+    fn test_no_annotation() {
+        let b = "this is not a short
+        short document
+        it has tiny sentences
+        but has enough sentences
+        or so I think";
+        let mut d = Document::new(b.to_string(), HashMap::new(), Metadata::default());
+
+        let annotator = TinyDocument::default();
+        annotator.annotate(&mut d);
+
+        assert_eq!(d.metadata().annotation(), None);
+    }
+}

--- a/src/transformers/tiny.rs
+++ b/src/transformers/tiny.rs
@@ -1,0 +1,20 @@
+use crate::pipelines::oscardoc::types::Document;
+
+use super::Annotate;
+
+pub struct TinyDocument {
+    threshold: usize,
+}
+impl Annotate for TinyDocument {
+    fn annotate(&self, doc: &mut Document) {
+        if doc.content().lines().count() < self.threshold {
+            doc.metadata_mut().set_annotation("tiny".to_string())
+        }
+    }
+}
+
+impl Default for TinyDocument {
+    fn default() -> Self {
+        Self { threshold: 5 }
+    }
+}

--- a/src/transformers/transform.rs
+++ b/src/transformers/transform.rs
@@ -2,8 +2,11 @@
 
 use std::ops::RangeInclusive;
 
+use warc::BufferedBody;
+
 use crate::pipelines::oscardoc::types::Document;
-pub trait Transform {
+
+pub trait Transform<T> {
     /// Takes ownership of [Document] and returns it.
-    fn transform(&self, doc: &mut Document) -> Vec<RangeInclusive<usize>>;
+    fn transform(&self, doc: &mut T) -> Vec<RangeInclusive<usize>>;
 }

--- a/src/transformers/transform.rs
+++ b/src/transformers/transform.rs
@@ -2,10 +2,6 @@
 
 use std::ops::RangeInclusive;
 
-use warc::BufferedBody;
-
-use crate::pipelines::oscardoc::types::Document;
-
 pub trait Transform<T> {
     /// Takes ownership of [Document] and returns it.
     fn transform(&self, doc: &mut T) -> Vec<RangeInclusive<usize>>;


### PR DESCRIPTION
Removes short sentences before running the PFilter.

Also fixes the probability score on non-multilingual documents.