### PR TITLE
fix: crash on absence of an empty rebuild folder

### DIFF
--- a/src/pipelines/oscardoc/types/rebuild.rs
+++ b/src/pipelines/oscardoc/types/rebuild.rs
@@ -277,11 +277,15 @@ impl<'a> RebuildWriters<'a, File> {
     ///
     /// Each language will have a possibly empty avro file, at `<dst>/<lang>.avro`.
     pub fn with_dst(dst: &Path) -> Result<Self, Error> {
+        if !dst.exists() {
+            std::fs::create_dir(dst)?;
+        }
+
         if dst.is_file() {
             error!("rebuild destination must be an empty folder!");
         };
 
-        if dst.read_dir()?.next().is_none() {
+        if !dst.read_dir()?.next().is_none() {
             error!("rebuild destination folder must be empty!");
         }
 


### PR DESCRIPTION
Probably related to #41 

Only a band-aid fix, we should revamp the IO error reporting.